### PR TITLE
Allow tool form to stray outside the window

### DIFF
--- a/CnCTDRAMapEditor/App.config
+++ b/CnCTDRAMapEditor/App.config
@@ -68,6 +68,9 @@
             <setting name="WallsToolDialogDefaultPosition" serializeAs="String">
                 <value>0, 0</value>
             </setting>
+            <setting name="clampActiveToolForm" serializeAs="String">
+                <value>False</value>
+            </setting>
         </MobiusEditor.Properties.Settings>
     </userSettings>
     <runtime>

--- a/CnCTDRAMapEditor/MainForm.cs
+++ b/CnCTDRAMapEditor/MainForm.cs
@@ -1043,6 +1043,11 @@ namespace MobiusEditor
 
         private void clampActiveToolForm()
         {
+            if (!Properties.Settings.Default.clampActiveToolForm)
+            {
+                return;
+            }
+
             if (activeToolForm == null)
             {
                 return;

--- a/CnCTDRAMapEditor/Properties/Settings.Designer.cs
+++ b/CnCTDRAMapEditor/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MobiusEditor.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -221,6 +221,18 @@ namespace MobiusEditor.Properties {
             }
             set {
                 this["WallsToolDialogDefaultPosition"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool clampActiveToolForm {
+            get {
+                return ((bool)(this["clampActiveToolForm"]));
+            }
+            set {
+                this["clampActiveToolForm"] = value;
             }
         }
     }

--- a/CnCTDRAMapEditor/Properties/Settings.settings
+++ b/CnCTDRAMapEditor/Properties/Settings.settings
@@ -53,5 +53,8 @@
     <Setting Name="WallsToolDialogDefaultPosition" Type="System.Drawing.Point" Scope="User">
       <Value Profile="(Default)">0, 0</Value>
     </Setting>
+    <Setting Name="clampActiveToolForm" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
If you have multiple monitors then having the tool window constrained to the main window is a big usability hit.